### PR TITLE
B4a 329 - Adds permissions Attribute on Entity Instance

### DIFF
--- a/src/back/models/Entity.js
+++ b/src/back/models/Entity.js
@@ -307,6 +307,8 @@ function Entity(attributeValues, options) {
           throw e;
         }
       }
+    } else {
+      this.permissions = null;
     }
     _attributeStorageValues.permissions = this.permissions;
   }

--- a/src/back/models/Entity.js
+++ b/src/back/models/Entity.js
@@ -312,7 +312,7 @@ function Entity(attributeValues, options) {
   Object.defineProperty(this, 'permissions', {
     value: this.permissions,
     enumerable: true,
-    writable: false,
+    writable: true,
     configurable: false
   });
 

--- a/src/back/models/Entity.js
+++ b/src/back/models/Entity.js
@@ -300,6 +300,7 @@ function Entity(attributeValues, options) {
       };
     }
   }
+  _attributeStorageValues.permissions = this.permissions;
 
   Object.defineProperty(this, 'id', {
     value: this.id,
@@ -391,7 +392,7 @@ function Entity(attributeValues, options) {
     }
 
     for (var attributeName in attributes) {
-      if (_cleanSet || attributeName === 'permissions') {
+      if (_cleanSet) {
         if (_attributeIsSet[attributeName]) {
           if (
             !_attributeStorageValues.hasOwnProperty(attributeName) ||

--- a/src/back/models/Entity.js
+++ b/src/back/models/Entity.js
@@ -275,7 +275,7 @@ function Entity(attributeValues, options) {
   }
 
   for (attribute in attributes) {
-    if (!_cleanSet || attribute === 'id') {
+    if (!_cleanSet || attribute === 'id' || attribute === 'permissions') {
       if (this[attribute] === null && attributes[attribute].default !== null) {
         this[attribute] = attributes[attribute].getDefaultValue(this);
       }
@@ -290,8 +290,26 @@ function Entity(attributeValues, options) {
     this.Entity.specification.name + '" (it has to be a valid uuid)'
   );
 
+  if (this.permissions) {
+    expect(this.permissions).to.be.an.instanceOf(Object);
+    for (var property in this.permissions) {
+      expect(this.permissions[property]).to.have.any.keys('write', 'read');
+      this.permissions[property] = {
+        read: Boolean(this.permissions[property].read),
+        write: Boolean(this.permissions[property].write)
+      };
+    }
+  }
+
   Object.defineProperty(this, 'id', {
     value: this.id,
+    enumerable: true,
+    writable: false,
+    configurable: false
+  });
+
+  Object.defineProperty(this, 'permissions', {
+    value: this.permissions,
     enumerable: true,
     writable: false,
     configurable: false
@@ -306,7 +324,8 @@ function Entity(attributeValues, options) {
           _cleanSet &&
           !_attributeStorageValues.hasOwnProperty(attributeName) &&
           !_attributeIsSet[attributeName] &&
-          attributeName !== 'id'
+          attributeName !== 'id' &&
+          attributeName !== 'permissions'
         ) {
           throw new errors.NotFetchedError(
             entity.Entity.specification.name,
@@ -322,7 +341,7 @@ function Entity(attributeValues, options) {
         attributeValue = value;
       },
       enumerable: true,
-      configurable: attributeName === 'id'
+      configurable: attributeName === 'id' || attributeName === 'permissions'
     });
   }
 
@@ -372,7 +391,7 @@ function Entity(attributeValues, options) {
     }
 
     for (var attributeName in attributes) {
-      if (_cleanSet) {
+      if (_cleanSet || attributeName === 'permissions') {
         if (_attributeIsSet[attributeName]) {
           if (
             !_attributeStorageValues.hasOwnProperty(attributeName) ||
@@ -581,6 +600,11 @@ var _entityAttributes = new AttributeDictionary({
   id: {
     type: 'String',
     default: uuid.v4
+  },
+  permissions: {
+    type: 'Object',
+    multiplicity: '0..1',
+    default: null
   }
 });
 

--- a/tests/unit/back/models/entity.test.js
+++ b/tests/unit/back/models/entity.test.js
@@ -921,6 +921,64 @@ describe('Entity', function () {
       expect(c11.permissions).to.not.equal(undefined);
       expect(c2.permissions).to.not.equal(undefined);
     });
+
+    it('expect to be null if is undefined or false', function () {
+      expect(new C1(
+        {
+          permissions: false
+        },
+        {
+          isNew: false
+        }
+      )).to.have.property('permissions')
+        .that.equals(null);
+
+      expect(c11.permissions).to.equal(null);
+    });
+
+    it('expect to clean permissions attribute', function () {
+      expect(new C1(
+        {
+          permissions: {
+            'id': {
+              'read': true,
+              'write': false,
+              'extremegohorse': false
+            }
+          }
+        },
+        {
+          isNew: false
+        }
+      )).to.have.property('permissions')
+        .that.deep.equals({
+          'id': {
+            'read': true
+          }
+        });
+    });
+
+    it('expect to have right permissions attribute', function () {
+      expect(new C1(
+        {
+          permissions: {
+            'id': {
+              'read': true,
+              'write': true
+            }
+          }
+        },
+        {
+          isNew: false
+        }
+      )).to.have.property('permissions')
+        .that.deep.equals({
+          'id': {
+            'read': true,
+            'write': true
+          }
+        });
+    });
   });
 
   describe('functional tests', function () {

--- a/tests/unit/back/models/entity.test.js
+++ b/tests/unit/back/models/entity.test.js
@@ -921,56 +921,6 @@ describe('Entity', function () {
       expect(c11.permissions).to.not.equal(undefined);
       expect(c2.permissions).to.not.equal(undefined);
     });
-
-    it.skip('expect to be valid', function () {
-      var c1Id = c1.permissions;
-      var c11Id = c11.permissions;
-      var c2Id = c2.permissions;
-
-      function isValid(id) {
-        var regex = '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-' +
-          '[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$';
-        return new RegExp(regex).test(id);
-      }
-
-      expect(isValid(c1Id)).to.equal(true);
-      expect(isValid(c11Id)).to.equal(true);
-      expect(isValid(c2Id)).to.equal(true);
-    });
-
-    it.skip('expect to generate different ids', function () {
-      expect(c1.id).to.not.equal(c11.id);
-      expect(c1.id).to.not.equal(c2.id);
-      expect(c2.id).to.not.equal(c11.id);
-    });
-
-    it.skip('expect to be given in the constructor', function () {
-      expect(new EntityProxy({
-        id: '00000000-0000-4000-a000-000000000000'
-      }))
-        .to.have.property('id')
-        .that.equals('00000000-0000-4000-a000-000000000000');
-    });
-
-    it.skip('expect to validate if given id is valid', function () {
-      expect(function () {
-        entity = new EntityProxy({id: 'itisnotvalid'});
-      }).to.throw(Error);
-    });
-
-    it.skip('expect to not be deleted', function () {
-      expect(function () {
-        delete c1.id;
-      }).to.throw(Error);
-
-      expect(c1).to.have.property('id');
-    });
-
-    it.skip('expect to be not writable', function () {
-      expect(function () {
-        c1.id = '00000000-0000-4000-a000-000000000000';
-      }).to.throw(Error);
-    });
   });
 
   describe('functional tests', function () {

--- a/tests/unit/back/models/entity.test.js
+++ b/tests/unit/back/models/entity.test.js
@@ -362,7 +362,8 @@ describe('Entity', function () {
           'c1A8',
           'c1A9',
           'c1A10',
-          'id'
+          'id',
+          'permissions'
         ]);
       }
     );
@@ -914,6 +915,64 @@ describe('Entity', function () {
     });
   });
 
+  describe('#permissions', function () {
+    it('expect not be undefined', function () {
+      expect(c1.permissions).to.not.equal(undefined);
+      expect(c11.permissions).to.not.equal(undefined);
+      expect(c2.permissions).to.not.equal(undefined);
+    });
+
+    it.skip('expect to be valid', function () {
+      var c1Id = c1.permissions;
+      var c11Id = c11.permissions;
+      var c2Id = c2.permissions;
+
+      function isValid(id) {
+        var regex = '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-' +
+          '[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$';
+        return new RegExp(regex).test(id);
+      }
+
+      expect(isValid(c1Id)).to.equal(true);
+      expect(isValid(c11Id)).to.equal(true);
+      expect(isValid(c2Id)).to.equal(true);
+    });
+
+    it.skip('expect to generate different ids', function () {
+      expect(c1.id).to.not.equal(c11.id);
+      expect(c1.id).to.not.equal(c2.id);
+      expect(c2.id).to.not.equal(c11.id);
+    });
+
+    it.skip('expect to be given in the constructor', function () {
+      expect(new EntityProxy({
+        id: '00000000-0000-4000-a000-000000000000'
+      }))
+        .to.have.property('id')
+        .that.equals('00000000-0000-4000-a000-000000000000');
+    });
+
+    it.skip('expect to validate if given id is valid', function () {
+      expect(function () {
+        entity = new EntityProxy({id: 'itisnotvalid'});
+      }).to.throw(Error);
+    });
+
+    it.skip('expect to not be deleted', function () {
+      expect(function () {
+        delete c1.id;
+      }).to.throw(Error);
+
+      expect(c1).to.have.property('id');
+    });
+
+    it.skip('expect to be not writable', function () {
+      expect(function () {
+        c1.id = '00000000-0000-4000-a000-000000000000';
+      }).to.throw(Error);
+    });
+  });
+
   describe('functional tests', function () {
     it('expect correct inheritances', function () {
       expect(classes.isGeneral(Entity, Entity)).to.equal(true);
@@ -1049,8 +1108,8 @@ describe('Entity', function () {
       expect(c11.c1M2(1, 2)).to.equal(3);
       expect(c11.c1M2('a', 'b')).to.equal('ab');
       expect(c11.c11M()).to.equal(
-        'c1A1c1A2c1A3c1A4c1A5c1A6c1A7c1A8c1A9c1A10idc11A1c1A1c1A2c1A3c1A4c1A5' +
-        'c1A6c1A7c1A8c1A9c1A10id'
+        'c1A1c1A2c1A3c1A4c1A5c1A6c1A7c1A8c1A9c1A10idpermissionsc11A1c1A1c1A2' +
+        'c1A3c1A4c1A5c1A6c1A7c1A8c1A9c1A10idpermissions'
       );
       expect(c2.constructor()).to.equal('constructor');
     });


### PR DESCRIPTION
- Default is null, which means "public".
- It is written while creating the instance.
- The permissions object is cleaned and boolean-casted.